### PR TITLE
Fix that Reichelt canonizer would not regognize its own URIs

### DIFF
--- a/WebApp/src/main/java/com/penguineering/cleanuri/sites/reichelt/ReicheltCanonizer.java
+++ b/WebApp/src/main/java/com/penguineering/cleanuri/sites/reichelt/ReicheltCanonizer.java
@@ -32,6 +32,9 @@ public class ReicheltCanonizer implements Canonizer {
 			.then("://www.reichelt.de/").anything().then("-p").capture().anything().endCapture().then(".html")
 			.anything().endOfLine().build();
 
+	static final VerbalExpression artidRegex2 = VerbalExpression.regex().startOfLine().then("http").anything()
+			.then("://www.reichelt.de/index.html?ARTICLE=").capture().anything().endCapture().endOfLine().build();
+
 	public ReicheltCanonizer() {
 	}
 
@@ -42,7 +45,8 @@ public class ReicheltCanonizer implements Canonizer {
 
 		final String authority = uri.getAuthority();
 
-		return authority != null && authority.endsWith("reichelt.de") && artidRegex.test(uri.toASCIIString());
+		return authority != null && authority.endsWith("reichelt.de") &&
+				(artidRegex.test(uri.toASCIIString()) || artidRegex2.test(uri.toASCIIString()));
 	}
 
 	@Override
@@ -59,7 +63,14 @@ public class ReicheltCanonizer implements Canonizer {
 		if (!isSuitable(uri))
 			throw new IllegalArgumentException("URI is not suitable for this extractor!");
 
-		final String artid = artidRegex.getText(uri.toASCIIString(), 1);
+		final String artid;
+
+		if (artidRegex.test(uri.toASCIIString()))
+			artid = artidRegex.getText(uri.toASCIIString(), 1);
+		else if (artidRegex2.test(uri.toASCIIString()))
+			artid = artidRegex2.getText(uri.toASCIIString(), 1);
+		else
+			artid = null;
 
 		return artid;
 	}


### PR DESCRIPTION
This popped up when checking #9